### PR TITLE
Persist dynamic schema to DB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "contacts-dxos",
       "version": "0.1.0",
       "dependencies": {
-        "@dxos/client": "0.5.0",
-        "@dxos/config": "0.5.0",
-        "@dxos/echo-schema": "0.5.0",
-        "@dxos/react-client": "0.5.0",
-        "@dxos/shell": "0.5.0",
+        "@dxos/client": "0.5.1-next.5a770e3",
+        "@dxos/config": "0.5.1-next.5a770e3",
+        "@dxos/echo-schema": "0.5.1-next.5a770e3",
+        "@dxos/react-client": "0.5.1-next.5a770e3",
+        "@dxos/shell": "0.5.1-next.5a770e3",
         "@phosphor-icons/react": "^2.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -57,58 +57,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@automerge/automerge": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-2.2.1.tgz",
-      "integrity": "sha512-LJwvVapEgAox0sEp0iDihE4wqsDAUyKt41Y5m3z1hHdF5DHa7IhqiHhGNCc59H8t3Zl3fnbTgtKabcMWFffvCQ==",
-      "dependencies": {
-        "@automerge/automerge-wasm": "0.16.0",
-        "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/@automerge/automerge-repo": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo/-/automerge-repo-1.1.9.tgz",
-      "integrity": "sha512-rh8PEgC0tDULrfnS5Gcq0U8yxqU0kuwcfx/JkQnOtp0FU/1IoalGAc3qgvceruRMOrzfXaktZ/r9a13I5UtiTQ==",
-      "dependencies": {
-        "@automerge/automerge": "^2.1.13",
-        "bs58check": "^3.0.1",
-        "cbor-x": "^1.3.0",
-        "debug": "^4.3.4",
-        "eventemitter3": "^5.0.1",
-        "fast-sha256": "^1.3.0",
-        "tiny-typed-emitter": "^2.1.0",
-        "ts-node": "^10.9.1",
-        "uuid": "^9.0.0",
-        "xstate": "^5.9.1"
-      }
-    },
-    "node_modules/@automerge/automerge-repo-storage-indexeddb": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-storage-indexeddb/-/automerge-repo-storage-indexeddb-1.1.9.tgz",
-      "integrity": "sha512-y/9nxCXZNWnnLM30ClaJ12wKB3Cotqw8i011zRB6mKB6cmy9l3QV7hK2d34ReEdRlmJ7gmO54kMvNnmBKcmmeA==",
-      "dependencies": {
-        "@automerge/automerge-repo": "1.1.9"
-      }
-    },
-    "node_modules/@automerge/automerge-repo/node_modules/xstate": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.12.0.tgz",
-      "integrity": "sha512-4W/Hj553mwVnTLQ1itc3rni/cGtM5OkjyavTjaxCelc0ZZKE/ks6tYllc98KbekIoUrEPm4CJH/wTB5p5pPGEw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/xstate"
-      }
-    },
     "node_modules/@automerge/automerge-wasm": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@automerge/automerge-wasm/-/automerge-wasm-0.12.0.tgz",
       "integrity": "sha512-MJVmw/83Uy7WuqA9Dac3VcLXpXENZSDu7hqxttdFyAYZXQYQugiU7R+RUO2sP7081J9gRUb2+73sYpNnSTwzYQ=="
-    },
-    "node_modules/@automerge/automerge/node_modules/@automerge/automerge-wasm": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge-wasm/-/automerge-wasm-0.16.0.tgz",
-      "integrity": "sha512-yYQ8WJED8f4cCnbIq+5SM8Q2tLK2VawDqLKptW+FTI5asklN8NEsHUHvDzqWUQARqGp6O9BnNd7ifQ0FPdks7A=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.2",
@@ -613,6 +565,8 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -624,75 +578,87 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@dxos/async": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/async/-/async-0.5.0.tgz",
-      "integrity": "sha512-TJRUJhZZtICai6FAnG4dAqY/QcYAIx4R76UjBrbymjaXUIraW3/P5ih7quGgFJmvSGRcwx2dt7amNwsK/wxOYA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/async/-/async-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-M7xsBcnhBXGevzG87fM7iQbL0N2sRC07CYezzDm/xfiyjmLu2eRMHO/x6n+08ta+dUNJLzQOi7Y5y9zmRLJgmg==",
       "dependencies": {
-        "@dxos/context": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "zen-observable": "^0.10.0",
         "zen-push": "^0.3.1"
       }
     },
     "node_modules/@dxos/automerge": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/automerge/-/automerge-0.5.0.tgz",
-      "integrity": "sha512-1JlqXqPg0bA3unvhRhNXs3GbKPSnuwvs81FSJMV5yWIyMA2WQcvYb4SGub49FhjpoTdYBp9Rq6JyBng1TeEa+Q==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/automerge/-/automerge-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-z7Th07gVhLuuda0THRSqz56NDO7WChrb9jjA6kD2X8t68lZPKxB0rIaixzITCwykhhlMQVqjSRig787KgKEfoQ==",
       "dependencies": {
-        "@automerge/automerge": "^2.1.13",
-        "@automerge/automerge-repo": "^1.1.5",
-        "@automerge/automerge-repo-storage-indexeddb": "^1.1.4",
         "@automerge/automerge-wasm": "^0.12.0",
         "bs58check": "^3.0.1",
         "cbor-x": "^1.5.4",
         "debug": "^4.3.4",
         "eventemitter3": "^5.0.1",
         "fast-sha256": "^1.3.0",
-        "xstate": "^4.37.0"
+        "isomorphic-ws": "^5.0.0",
+        "ws": "^8.14.2",
+        "xstate": "^5.9.1"
+      }
+    },
+    "node_modules/@dxos/automerge/node_modules/xstate": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.13.0.tgz",
+      "integrity": "sha512-Z0om784N5u8sAzUvQJBa32jiTCIGGF/2ZsmKkerQEqeeUktAeOMK20FIHFUMywC4GcAkNksSvaeX7lwoRNXPEQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
       }
     },
     "node_modules/@dxos/client": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/client/-/client-0.5.0.tgz",
-      "integrity": "sha512-aX8GgxJYI/qtRYXln7ZXyiEHWVSMRnyQ/AZuosS1h4Kfx/Y3A6U0DOl8FkB2aaxknNuUevtnKnry2rLX37VBlw==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/client/-/client-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-5ksFDHy5uN30t820gH/K3ZNLXKQeJJT73V1fVeYe6IEAhaSKczRUTq4+rgaxTw9NFSGUYWLlO4D5inX1AFlYQw==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/client-protocol": "0.5.0",
-        "@dxos/client-services": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/config": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/credentials": "0.5.0",
-        "@dxos/crypto": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/echo-db": "0.5.0",
-        "@dxos/echo-pipeline": "0.5.0",
-        "@dxos/echo-schema": "0.5.0",
-        "@dxos/indexing": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/messaging": "0.5.0",
-        "@dxos/network-manager": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/rpc-tunnel": "0.5.0",
-        "@dxos/timeframe": "0.5.0",
-        "@dxos/tracing": "0.5.0",
-        "@dxos/util": "0.5.0",
-        "@dxos/websocket-rpc": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/client-protocol": "0.5.1-next.5a770e3",
+        "@dxos/client-services": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/config": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/credentials": "0.5.1-next.5a770e3",
+        "@dxos/crypto": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/echo-db": "0.5.1-next.5a770e3",
+        "@dxos/echo-pipeline": "0.5.1-next.5a770e3",
+        "@dxos/echo-schema": "0.5.1-next.5a770e3",
+        "@dxos/indexing": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/kv-store": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/messaging": "0.5.1-next.5a770e3",
+        "@dxos/network-manager": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/rpc-tunnel": "0.5.1-next.5a770e3",
+        "@dxos/timeframe": "0.5.1-next.5a770e3",
+        "@dxos/tracing": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
+        "@dxos/websocket-rpc": "0.5.1-next.5a770e3",
         "base-x": "~3.0.9",
+        "jwt-decode": "^4.0.0",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "lodash.isequalwith": "^4.4.0"
@@ -702,89 +668,90 @@
       }
     },
     "node_modules/@dxos/client-protocol": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/client-protocol/-/client-protocol-0.5.0.tgz",
-      "integrity": "sha512-xfYXcieWdhFRHhdsvGQ0zwnYEoa9XMQ1olqvBN5gzMQau+6GPVXWyW9Pz+98L4vE3YdL5o+kxE+GgNYOfaQPWA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/client-protocol/-/client-protocol-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-obIAVyaqcnl4NIobs5Tza4UujIKcYgIIt6WZVTGrnM7JI1XF/oRedLG6l2I0V1ejXtzSMLHbjN8if9IUaDfv/A==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/config": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/echo-db": "0.5.0",
-        "@dxos/echo-schema": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/rpc": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/config": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/echo-db": "0.5.1-next.5a770e3",
+        "@dxos/echo-schema": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
         "base-x": "~3.0.9"
       }
     },
     "node_modules/@dxos/client-services": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/client-services/-/client-services-0.5.0.tgz",
-      "integrity": "sha512-csirI+UB1dnsa1w8kbFZnKaqL8SebLFd8HfSsL3MfIKCDgfO1t7A7mY3NrAsjzKgxaA0H+nK5T8MQyPL2PZrKw==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/client-services/-/client-services-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-+XDVGclBrFpBH+rZaX0Yhz/Wm/+oIxu/GVWUlGC1hQPg+yBdcqV7pa7IBemfuLqq0kM0rnX4Gug29AWaOJP8ng==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/automerge": "0.5.0",
-        "@dxos/client-protocol": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/config": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/credentials": "0.5.0",
-        "@dxos/crypto": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/echo-db": "0.5.0",
-        "@dxos/echo-pipeline": "0.5.0",
-        "@dxos/echo-schema": "0.5.0",
-        "@dxos/feed-store": "0.5.0",
-        "@dxos/indexing": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keyring": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/lock-file": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/messaging": "0.5.0",
-        "@dxos/network-manager": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/random-access-storage": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/teleport": "0.5.0",
-        "@dxos/teleport-extension-gossip": "0.5.0",
-        "@dxos/teleport-extension-object-sync": "0.5.0",
-        "@dxos/timeframe": "0.5.0",
-        "@dxos/tracing": "0.5.0",
-        "@dxos/util": "0.5.0",
-        "@dxos/websocket-rpc": "0.5.0",
-        "level": "^8.0.1",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/automerge": "0.5.1-next.5a770e3",
+        "@dxos/client-protocol": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/config": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/credentials": "0.5.1-next.5a770e3",
+        "@dxos/crypto": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/echo-db": "0.5.1-next.5a770e3",
+        "@dxos/echo-pipeline": "0.5.1-next.5a770e3",
+        "@dxos/echo-protocol": "0.5.1-next.5a770e3",
+        "@dxos/echo-schema": "0.5.1-next.5a770e3",
+        "@dxos/feed-store": "0.5.1-next.5a770e3",
+        "@dxos/indexing": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keyring": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/kv-store": "0.5.1-next.5a770e3",
+        "@dxos/lock-file": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/messaging": "0.5.1-next.5a770e3",
+        "@dxos/network-manager": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/random-access-storage": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/teleport": "0.5.1-next.5a770e3",
+        "@dxos/teleport-extension-gossip": "0.5.1-next.5a770e3",
+        "@dxos/teleport-extension-object-sync": "0.5.1-next.5a770e3",
+        "@dxos/timeframe": "0.5.1-next.5a770e3",
+        "@dxos/tracing": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
+        "@dxos/websocket-rpc": "0.5.1-next.5a770e3",
         "platform": "^1.3.6"
       }
     },
     "node_modules/@dxos/codec-protobuf": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/codec-protobuf/-/codec-protobuf-0.5.0.tgz",
-      "integrity": "sha512-TX6EG0/zHPCGLBnWfRhKfKrnjwKojs9kXz22Ub4YJwC9JrJ9Od17+YYuFOvVXByD2oIzlozqQPkUg5/5BtlsFA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/codec-protobuf/-/codec-protobuf-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-FgxM7OhUUVF7WoCg2ceBlPn463lQfoYc+E9laSLlYQZRKs8qki1ngceOcyvFfxp9Tl2PSPJYk3D3tSJdkL58tw==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "compress-json": "^2.1.2",
         "lodash.merge": "^4.6.2",
-        "protobufjs": "^7.2.2"
+        "protobufjs": "^7.2.5"
       }
     },
     "node_modules/@dxos/config": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/config/-/config-0.5.0.tgz",
-      "integrity": "sha512-lmW0EPC+VfDABEELCUBicorE2jLi6XG1dLsRp+jgfTBinDoiHz0OWVu96fzCw426S5kMRBL7ilV2IphpZqE3Zw==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/config/-/config-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-c6B9xuQeMMa6mR7HRDNXKX5MC4LaLUKbL+1A5SCuzww7XMxhH2+Ian8LvqBslRXWkIYZa2VdJBE4KNajQEipCw==",
       "dependencies": {
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/tracing": "0.5.0",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/tracing": "0.5.1-next.5a770e3",
         "boolean": "^3.0.1",
         "js-yaml": "^4.1.0",
         "localforage": "^1.10.0",
@@ -796,34 +763,34 @@
       }
     },
     "node_modules/@dxos/context": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/context/-/context-0.5.0.tgz",
-      "integrity": "sha512-7TD8ZOF18IGU7vBM5wjziK9b4M3AvnSut8kTkaYVmEDGnqi6XA2nADGJMKGP7ABPF5cSP135cI3agmf5qgPA+Q==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/context/-/context-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-aXtiUA+jpX8BUTl1tpi7+YDlEEgH//bLuFFawaKdPYs+f76nMkBJGXexy3bb8OyVDAQR7TYJw1iG+rXIzUE5eg==",
       "dependencies": {
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/credentials": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/credentials/-/credentials-0.5.0.tgz",
-      "integrity": "sha512-nnusKgK/Ak9dUPyhN4xlJaJhOxY0zwpko2xEFxSC8ySaDbXnslzhdHKH0wTdO0pdeloNcwC25QzKMi0Vj+H/Wg==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/credentials/-/credentials-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-IWBbLNfzPSkMysIKfrQhvWnd9RXY+jXCOfl9ydx46kCtoQ7YDwRJYZavi9W4/KUoNuXOW7+Ghszwm3QRJEoCpQ==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/crypto": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/feed-store": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keyring": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/timeframe": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/crypto": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/feed-store": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keyring": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/timeframe": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "bip39": "^3.0.4",
         "buffer-json-encoding": "^1.0.2",
         "encoding-down": "^6.3.0",
@@ -839,109 +806,126 @@
       }
     },
     "node_modules/@dxos/crypto": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/crypto/-/crypto-0.5.0.tgz",
-      "integrity": "sha512-u8OkejhNU8hVyAtCAwpOytV/csW4C8DzfY3UKGw1mHWQD1kVad0+6So/cGH+QC/1meJop81GPZDWeMikpsPoqg==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/crypto/-/crypto-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-j0znAzI74up4vgahkHFCKjYAcEZ2qqX3bwq1NRb8i54rUfT1gxZdnh04ynAJ5uIIEVQzxW0aaZf4R27MdBDA9A==",
       "dependencies": {
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/node-std": "0.5.0",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
         "hypercore-crypto": "^2.3.0"
       }
     },
     "node_modules/@dxos/debug": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/debug/-/debug-0.5.0.tgz",
-      "integrity": "sha512-rltUJCRT6a3j7/Gl3bu+QbpNpPP1VWjKY5HDy6nlusa+h35lsIQDOIjv+nsydqMewY+uosSr/0YJxJRyuLCm4w==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/debug/-/debug-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-+jjUeKVwTNiF9pCCulp3lF2gXug8g7Ct/718u8bGDGAdCYFD/4to7vz9KkIdJvCCQkvx0gak2hasklHAL8uC1Q==",
       "dependencies": {
-        "@dxos/node-std": "0.5.0"
+        "@dxos/node-std": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/display-name": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/display-name/-/display-name-0.5.0.tgz",
-      "integrity": "sha512-5F1I1Ernla5nP3SI0Upd8wSTABSeHnywJ2Gr2GPAhnFIkM98n3hekwsleAOzchG33Ott0nxnPjiPz13LEf5mHQ=="
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/display-name/-/display-name-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-InMBPIGdWMDIg8LjE0BfUPOu3iNBqUcv0g6YtNIuDd4GdjH9bvBmrn4CB+Mv4SXagl9LBbSGnUROSnr16CyETg=="
     },
     "node_modules/@dxos/echo-db": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/echo-db/-/echo-db-0.5.0.tgz",
-      "integrity": "sha512-C4vrk1uIgfB7N0QdSG/JcRZVQQLqY8Up2EjXt6fv8kvGcwmO+kncWMPGQsEAvcvzpmke1UTSOjUnI6ZQbfpvzg==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/echo-db/-/echo-db-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-9g8XsY08USeNhWOyYwK4Wc3wNmJhLWKIh4VAraMs496ELB/7detDZ18KUi/Csdz6pHP8TcBshZpA7Vr4hb2/Zg==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/automerge": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/echo-pipeline": "0.5.0",
-        "@dxos/echo-schema": "0.5.0",
-        "@dxos/echo-signals": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/random-access-storage": "0.5.0",
-        "@dxos/tracing": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/automerge": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/echo-pipeline": "0.5.1-next.5a770e3",
+        "@dxos/echo-protocol": "0.5.1-next.5a770e3",
+        "@dxos/echo-schema": "0.5.1-next.5a770e3",
+        "@dxos/echo-signals": "0.5.1-next.5a770e3",
+        "@dxos/indexing": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/kv-store": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/random-access-storage": "0.5.1-next.5a770e3",
+        "@dxos/teleport": "0.5.1-next.5a770e3",
+        "@dxos/tracing": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "@effect/schema": "0.64.7",
         "@orama/orama": "^2.0.8",
         "effect": "2.4.9",
+        "level": "^8.0.1",
         "lodash.defaultsdeep": "^4.6.1",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0"
       }
     },
     "node_modules/@dxos/echo-pipeline": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/echo-pipeline/-/echo-pipeline-0.5.0.tgz",
-      "integrity": "sha512-NNI/KYhqvZK06GW7OcooQvDd6KoF9k/SdYVlwpJWRqiKUB3ofqTjtVtrLyljMPXT6e+haqILvrLvnssTNEtpUw==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/echo-pipeline/-/echo-pipeline-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-q8HuVXnlKKFkYWg8xRUIvyU4BO5Uq0Pspxz1Z3lMObE4p1FL9elSsRNFZQF2GSoAlaopvparxRDV993Kh2jiQQ==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/automerge": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/credentials": "0.5.0",
-        "@dxos/crypto": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/echo-schema": "0.5.0",
-        "@dxos/feed-store": "0.5.0",
-        "@dxos/hypercore": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keyring": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/messaging": "0.5.0",
-        "@dxos/network-manager": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/random-access-storage": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/teleport": "0.5.0",
-        "@dxos/teleport-extension-automerge-replicator": "0.5.0",
-        "@dxos/teleport-extension-gossip": "0.5.0",
-        "@dxos/teleport-extension-object-sync": "0.5.0",
-        "@dxos/teleport-extension-replicator": "0.5.0",
-        "@dxos/timeframe": "0.5.0",
-        "@dxos/tracing": "0.5.0",
-        "@dxos/typings": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/automerge": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/credentials": "0.5.1-next.5a770e3",
+        "@dxos/crypto": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/echo-protocol": "0.5.1-next.5a770e3",
+        "@dxos/echo-schema": "0.5.1-next.5a770e3",
+        "@dxos/feed-store": "0.5.1-next.5a770e3",
+        "@dxos/hypercore": "0.5.1-next.5a770e3",
+        "@dxos/indexing": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keyring": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/kv-store": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/messaging": "0.5.1-next.5a770e3",
+        "@dxos/network-manager": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/random-access-storage": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/teleport": "0.5.1-next.5a770e3",
+        "@dxos/teleport-extension-automerge-replicator": "0.5.1-next.5a770e3",
+        "@dxos/teleport-extension-gossip": "0.5.1-next.5a770e3",
+        "@dxos/teleport-extension-object-sync": "0.5.1-next.5a770e3",
+        "@dxos/teleport-extension-replicator": "0.5.1-next.5a770e3",
+        "@dxos/timeframe": "0.5.1-next.5a770e3",
+        "@dxos/tracing": "0.5.1-next.5a770e3",
+        "@dxos/typings": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "abstract-level": "^1.0.2",
         "crc-32": "^1.2.2",
         "level": "^8.0.1",
         "level-transcoder": "^1.0.1"
       }
     },
-    "node_modules/@dxos/echo-schema": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/echo-schema/-/echo-schema-0.5.0.tgz",
-      "integrity": "sha512-FrpU3Qu9YIhmuMZ+YAbaxxYlr/lPPGBAg5dHxObjZJmAdGabH4ASFN5sc+HNqSBWjNxA5kqvBtqODJnOXAyfGw==",
+    "node_modules/@dxos/echo-protocol": {
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/echo-protocol/-/echo-protocol-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-ZdtEBtWS0EBABIClvtN5MN0Z8pxVzWzsm9bNI67w17NzOFNhPk6lK4DZXz1C6Bezs9jTIpVdNddoxlwZUMRt5A==",
       "dependencies": {
-        "@dxos/echo-signals": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
+        "@dxos/protocols": "0.5.1-next.5a770e3"
+      }
+    },
+    "node_modules/@dxos/echo-schema": {
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/echo-schema/-/echo-schema-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-VMmN+Pm+aePGfNQn2B0zGI2BSOLdSI4zqNBVik8TSrWljKUACefcuIc3xf5YLIk5DMeiWKzNLBfv5/Xitv+IkQ==",
+      "dependencies": {
+        "@dxos/echo-protocol": "0.5.1-next.5a770e3",
+        "@dxos/echo-signals": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
         "@effect/schema": "0.64.7",
         "@preact/signals-core": "^1.6.0",
         "effect": "2.4.9",
@@ -949,9 +933,9 @@
       }
     },
     "node_modules/@dxos/echo-signals": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/echo-signals/-/echo-signals-0.5.0.tgz",
-      "integrity": "sha512-QT7GE1qkBiwFPsflH0013KfpnE/fMUNLPblu4M2/v7+I7dwmGXj8V4c8bCSaRJ3S1h+8+WAKKUQ4DJAITGk/Wg==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/echo-signals/-/echo-signals-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-3UL/DT7C07/2gvpMs0KMT61JPfgNvlUStySNr+KrIAtK9oA6UAY8IjXqQgHyhD4w6ngcJ3bS54yrrU9yLBz23g==",
       "dependencies": {
         "@preact/signals": "^1.2.1",
         "@preact/signals-core": "^1.6.0",
@@ -963,46 +947,46 @@
       }
     },
     "node_modules/@dxos/feed-store": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/feed-store/-/feed-store-0.5.0.tgz",
-      "integrity": "sha512-fLeOkKSEH9DnRnXB5uYG9/I+o1P2z2XBLCW+DLVEqWYEaLkAA1jR9KDNDTo2WkcQSCqijm8EMqIh4Kj0QBUBeA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/feed-store/-/feed-store-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-fZZHLBzjAMODafsay3f068w731tQzPBaAgh0L+KFXBembf9elbu4jaaMofc3izlbG5QJtZcVpcwQN4zD1MSePg==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/crypto": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/hypercore": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keyring": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/random-access-storage": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/crypto": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/hypercore": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keyring": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/random-access-storage": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "lodash.defaultsdeep": "^4.6.1",
         "race-as-promised": "^0.0.2",
         "streamx": "^2.12.5"
       },
       "optionalDependencies": {
-        "@dxos/random": "0.5.0"
+        "@dxos/random": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/hypercore": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/hypercore/-/hypercore-0.5.0.tgz",
-      "integrity": "sha512-QF5gPAYNwMewLXfAr/MAdoQtyhJaw0/e/z6xpJoKdYAOODlnm+OkH2oY+UsJJN5LtO9zmNAK6TSWC0kgewLKJA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/hypercore/-/hypercore-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-RiBCAKh93inru+GL24J0LdBPxqACqoBe3Xu6e5srbUxeFQgv/TYrB5XV+ggmoHgvEqWovAG4ECk5Et/fN5cyCg==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/crypto": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/random-access-storage": "0.5.0",
-        "@dxos/typings": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/crypto": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/random-access-storage": "0.5.1-next.5a770e3",
+        "@dxos/typings": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "readable-stream": "^3.6.0",
         "sodium-native": "^3.2.0",
         "sodium-universal": "^3.0.2",
@@ -1010,86 +994,93 @@
       }
     },
     "node_modules/@dxos/indexing": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/indexing/-/indexing-0.5.0.tgz",
-      "integrity": "sha512-n7etRpr8Ne7i1tMPwgtz/uupG5KO6417gasSPh3bsfxnP7JQF1rumMIy5v1A4d1R2N8d0rWz6Yw/ZiixQFSrgQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/indexing/-/indexing-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-k3CIVP+TVFBGW2yUWvhrDYVhXOvL2vxmgAWqZqKTlEP1CdL42+Nt3sRPtELeFCx/TNKqTYNONPyZQFgbgD0ktA==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/automerge": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/echo-db": "0.5.0",
-        "@dxos/echo-pipeline": "0.5.0",
-        "@dxos/echo-schema": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/random-access-storage": "0.5.0",
-        "@dxos/tracing": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/automerge": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/echo-protocol": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/kv-store": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/random-access-storage": "0.5.1-next.5a770e3",
+        "@dxos/tracing": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "@orama/orama": "^2.0.8",
-        "abstract-level": "^1.0.2",
-        "level": "^8.0.1",
+        "level-transcoder": "^1.0.1",
         "lodash.isequal": "^4.5.0"
       }
     },
     "node_modules/@dxos/invariant": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/invariant/-/invariant-0.5.0.tgz",
-      "integrity": "sha512-C5D/FdjW4KJx0UJEaN4aB5D8xLK7JHWo0DAoF9fTV7R32pqjCEXQ8KUbInGqMRbGfqBH25hrVU5jakaqxNticQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/invariant/-/invariant-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-znLZPe/KKW06HJmU2bjHhQR4YSJkEBe35bYZcp39bf+RbQ6sVdPTMId0Yi/unRmF9B5+spHwUkw9uqmeyqdpWw==",
       "dependencies": {
-        "@dxos/node-std": "0.5.0"
+        "@dxos/node-std": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/keyring": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/keyring/-/keyring-0.5.0.tgz",
-      "integrity": "sha512-YFKZYMWgso6xJLgQq5zKWiO4UqC/NETjp9yJMN84D21XWZAiZiUbD4L0E9sjHRdT6jiUHJ1QhvywCNEdlSlqJQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/keyring/-/keyring-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-+hiXQmIM9rU0bmcYkRsAsRbLcqq56kBWbyqk76/UwVchQq4d/ML5Saw0HAQE1qlOBgPp4VXRtM/A1IAoisNDOw==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/crypto": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/random-access-storage": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/crypto": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/random-access-storage": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/keys": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/keys/-/keys-0.5.0.tgz",
-      "integrity": "sha512-l3iDDsbnvAZNw4oS5NUgMVhsYe3bGBi9c3vPb0dzjFBgshrSHU+7XKC1hWsNCNbs35jGnApUd6mXI6ATVKhs5Q==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/keys/-/keys-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-QCJDghdPre3QO55yVqM9dsJmUc69xwnXBL/5PqF+EoNL2d6ELX2BwBL1gle7A4qFFdaeoRAZcHRTtd6yOLmUjQ==",
       "dependencies": {
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/node-std": "0.5.0"
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3"
+      }
+    },
+    "node_modules/@dxos/kv-store": {
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/kv-store/-/kv-store-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-pmQtu0dZVFeJfX//MvNGyk+TR5rQIA/+q+RNdvyjxyagMssTkHCSuGGL7aUZG+smQ4yWgkdsB1iPJkYOI+CZrw==",
+      "dependencies": {
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "abstract-level": "^1.0.2",
+        "level": "^8.0.1"
       }
     },
     "node_modules/@dxos/lock-file": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/lock-file/-/lock-file-0.5.0.tgz",
-      "integrity": "sha512-y4XefyAS9bg/C0htfAukFrFKzFUjiG6ZHPHh+OhK5kQnyV9KdgXvPjgl0TA/xueC7z2vHi5PRXXF5koMW1py9w==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/lock-file/-/lock-file-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-m47VgqF9nGlkyPjGSqMubI4TnjHaQYHGY5HnpoWFPUdWSYV65xQCUKo4IoNwqDjrCqLYWCaSd+Bmv0zFc3n1Xw==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
         "fs-ext": "^2.0.0"
       }
     },
     "node_modules/@dxos/log": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/log/-/log-0.5.0.tgz",
-      "integrity": "sha512-XAokhbJgtrzVicnnD2En6xpeZxJtVS4NVLj+5OjYgIC+xJdANrFD8usuY0LO7n/AYBczzKDXlaOWpKzNBOpkmA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/log/-/log-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-EXYbAQmAIhjK5oclaeYz6y+wAkdoW+SXGmGEfL+MfOXh7SB/peIb2TMis+CshNTMbVGZsh+0iqscRpUEHtUNIg==",
       "dependencies": {
-        "@dxos/node-std": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "chalk": "^4.1.0",
         "js-yaml": "^4.1.0",
         "lodash.defaultsdeep": "^4.6.1",
@@ -1099,46 +1090,46 @@
       }
     },
     "node_modules/@dxos/messaging": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/messaging/-/messaging-0.5.0.tgz",
-      "integrity": "sha512-aZDqXYGw8qydnLVnWv91oV5l1UvltIv5M6PFzYmI48q/OXuI27cpjNSitN6TJfdStui4xJof29swOjn3ikWS8Q==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/messaging/-/messaging-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-sh1FUPZ6m5HWUUZdTlx6HrjTaMs0nzoNrlO+r2K8UJdp+gaqMkxNwHLAguM+iTxpwtKIxw1jaqnVjfBSEomNJQ==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/util": "0.5.0",
-        "isomorphic-ws": "^4.0.1",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
+        "isomorphic-ws": "^5.0.0",
         "ws": "^8.14.2"
       }
     },
     "node_modules/@dxos/network-manager": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/network-manager/-/network-manager-0.5.0.tgz",
-      "integrity": "sha512-dbpa4Z/UzLKs22DPrRACtHQnpqPP2y2FAd2Ts/DDSRbsWnfWKNl8xypxCLGiwtVrecWaPlsFM2+SBxgy8yqc3Q==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/network-manager/-/network-manager-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-JndWdGo+VFrMzWDfA/mJ3LgWmLAj94WavFKtOl+1M2oIJ5a8JXssVqTGmyEO+kKifvna1RdH3SzUhzhnD5uCTQ==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/credentials": "0.5.0",
-        "@dxos/crypto": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/messaging": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/teleport": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/credentials": "0.5.1-next.5a770e3",
+        "@dxos/crypto": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/messaging": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/teleport": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "@koush/wrtc": "^0.5.3",
-        "isomorphic-ws": "^4.0.1",
+        "isomorphic-ws": "^5.0.0",
         "nanomessage-rpc": "^3.0.0",
         "node-datachannel": "^0.5.5",
         "p-defer": "^3.0.0",
@@ -1150,9 +1141,9 @@
       }
     },
     "node_modules/@dxos/node-std": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/node-std/-/node-std-0.5.0.tgz",
-      "integrity": "sha512-pCxoTS2VuqcB9FHgNvr25OrhdXGzdeEMivOG7uUT5AWU34wUFy9/2Hy6iOrdcVcuXoy7M/lFoq+sFpEU3c1tfw==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/node-std/-/node-std-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-/Ih1fOUIw4tprF+tIJnPuizM7v59JfFWpSWSncOIp+XFS7EpEI2LH5qQyR2K02suhWnlms1dTTF70iqO6lQ3Bg==",
       "dependencies": {
         "assert": "^2.0.0",
         "events": "^3.3.0",
@@ -1162,41 +1153,41 @@
       }
     },
     "node_modules/@dxos/protocols": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/protocols/-/protocols-0.5.0.tgz",
-      "integrity": "sha512-vn49Q5HxRAxdzLt4zgXEdxCxOu7Yse+dlljaEzQxHO7kYVC3u9150XwXJzgmET+dJwBy8Up21Kv/bB00GYwnAg==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/protocols/-/protocols-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-bk5taByUmmf5q4ztk8L5FruC4szZrbNNPfDHN7IMQ+Xsxrrb83Rbbyy8Bw8NFKdbiHppnr+83ifEMnNOU1wpgw==",
       "dependencies": {
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/timeframe": "0.5.0"
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/timeframe": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/random": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/random/-/random-0.5.0.tgz",
-      "integrity": "sha512-pnRBc8QfdTuJwpA4h/g9GoSCfRTlPSG5h8uqM0t/nrK46jKtwt0ynJCtcjvjnpWn1gsWuAFtvHgq9EcpAPINVw==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/random/-/random-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-c8ekpGZKVzpUEqFDOAaTAIoDTAOiaPDGrolgWlSuloxpgjsbDMYtYKGYL/e0yllwisK0+JAOcySXLPbKhDq+Zw==",
       "optional": true,
       "dependencies": {
-        "@dxos/node-std": "0.5.0",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
         "@ngneat/falso": "^7.1.1",
         "seedrandom": "^3.0.5",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/@dxos/random-access-storage": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/random-access-storage/-/random-access-storage-0.5.0.tgz",
-      "integrity": "sha512-pWBYI9PJ9hf7agrNxXK0LKPYXVvq8yD53ZTB3SJ8NIilPAnZeO6WE54d4NNJ68JYYivPX/W8WLKfy0xFreKDuQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/random-access-storage/-/random-access-storage-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-yZaSvbkigZngED/LrfXkkHHfJmS8S3sLgER6F1UEJrFsYNYD/P2IGyXd7zIro+snaOYQrcaVNVe2r8cUFI3+wQ==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/tracing": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/tracing": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "buffer-alloc": "^1.1.0",
         "buffer-from": "^0.1.1",
         "del": "^5.1.0",
@@ -1220,11 +1211,11 @@
       }
     },
     "node_modules/@dxos/react-async": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/react-async/-/react-async-0.5.0.tgz",
-      "integrity": "sha512-Hv5hLqKk1wdUliXn4dMeYL8oThUUs/bz3/QRhAnvnXghcoQMvuF38cGlUzaj9PcnCHY+xVhBf8Y+B7GChbg2IA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/react-async/-/react-async-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-NCRAWb00tiByfdbWmjK4AayTh1lbkRx2SF50/pBc5UT8ShOHd/qR0Q4wAb/692gbz1Sjx1avP0sgS3k7SGtNKg==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
         "immutability-helper": "^3.0.2"
       },
       "peerDependencies": {
@@ -1233,24 +1224,24 @@
       }
     },
     "node_modules/@dxos/react-client": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/react-client/-/react-client-0.5.0.tgz",
-      "integrity": "sha512-KKQnhO2FbI2Ea7SQxgA0V7G3Ut4yXJw4CLXSFuObTmyCuEzeznaj2lP50u0xFGhentZ+1kuCQIajPMYqhr6ELQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/react-client/-/react-client-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-F3nm/SXGQjXSB4okGcUxfcov7VgnMcq7h54tKZSiQ05Og12UJ6tdGeynKROclPtj/7u+oebziFp1JVU34DcdxA==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/client": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/config": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/echo-signals": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/react-async": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/client": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/config": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/echo-signals": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/react-async": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       },
       "optionalDependencies": {
-        "@dxos/random": "0.5.0",
+        "@dxos/random": "0.5.1-next.5a770e3",
         "yjs": "^13.6.10"
       },
       "peerDependencies": {
@@ -1259,9 +1250,9 @@
       }
     },
     "node_modules/@dxos/react-hooks": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/react-hooks/-/react-hooks-0.5.0.tgz",
-      "integrity": "sha512-Pyr+Q5MwqH2yqIXhQtwqbSoTUD00MgbxhZA//ysFVBp5ePAwob6a77Ou2n+ULr6/SeoKR4ZbmXFU//LUaVX42w==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/react-hooks/-/react-hooks-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-+RmqMVmSGkCXmlf1i4LzKKm119t8C3Dy83X6Rt/erUTT2hp+dwJDJFc7+EBawcgcfeD1jsOMnnhxDTtoYCoo7g==",
       "dependencies": {
         "alea": "^1.0.1"
       },
@@ -1271,11 +1262,11 @@
       }
     },
     "node_modules/@dxos/react-input": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/react-input/-/react-input-0.5.0.tgz",
-      "integrity": "sha512-SYXKIs8jPgmEbnCS1uSVTGjUEO1s/dsm6z34aop/OAAV5hRiGaUqpUTwroEhJslz5wQVyiDib9Akf/hNtzZRzQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/react-input/-/react-input-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-THL0Slt3sWzoFdu7LiL2NvY8VYY7urlJhXCsFNjWEdeEer6e23qex9WRIzZ6PkwfUQMy7vpFrTC5Q0pQj0cY+g==",
       "dependencies": {
-        "@dxos/react-hooks": "0.5.0",
+        "@dxos/react-hooks": "0.5.1-next.5a770e3",
         "@radix-ui/react-compose-refs": "^1.0.0",
         "@radix-ui/react-context": "^1.0.0",
         "@radix-ui/react-primitive": "^1.0.2",
@@ -1290,11 +1281,11 @@
       }
     },
     "node_modules/@dxos/react-list": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/react-list/-/react-list-0.5.0.tgz",
-      "integrity": "sha512-pWEfSHqcttOfTPuLzdqKLvqPzyYWWAqNAkhKZ3QZUqreQO+SNHoPwKHOAVqpaNhB/f45gZefQjhyj8ja4R/eOA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/react-list/-/react-list-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-ygCR8LqJxJYVXPluSC9QDItJUt4NilWUR1meV3uEW6sqPSAwcOU/KTOQvalcSiZTz6DsHM0HjqYivnsJBfDKHQ==",
       "dependencies": {
-        "@dxos/react-hooks": "0.5.0",
+        "@dxos/react-hooks": "0.5.1-next.5a770e3",
         "@radix-ui/react-collapsible": "^1.0.2",
         "@radix-ui/react-context": "^1.0.0",
         "@radix-ui/react-primitive": "^1.0.2",
@@ -1308,15 +1299,15 @@
       }
     },
     "node_modules/@dxos/react-ui": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/react-ui/-/react-ui-0.5.0.tgz",
-      "integrity": "sha512-pwGdBmaRPlaYwGpHVIJjY0YWo7qnzpt+RBGXcYlivLwAE+gas3mjRY5jnkpqPBkERNos2P9eq0L/dWzsKqRYgQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/react-ui/-/react-ui-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-p6NoKJjBUPxcrnKA2wDbOzKVZrprKEoagB6tVfu2ygaHg60aUXVh2TkB7fJ8NWrkbb5emOf7NCl9e4Cqwg83EA==",
       "dependencies": {
-        "@dxos/log": "0.5.0",
-        "@dxos/react-hooks": "0.5.0",
-        "@dxos/react-input": "0.5.0",
-        "@dxos/react-list": "0.5.0",
-        "@dxos/react-ui-types": "0.5.0",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/react-hooks": "0.5.1-next.5a770e3",
+        "@dxos/react-input": "0.5.1-next.5a770e3",
+        "@dxos/react-list": "0.5.1-next.5a770e3",
+        "@dxos/react-ui-types": "0.5.1-next.5a770e3",
         "@fluentui/react-tabster": "^9.19.0",
         "@radix-ui/react-alert-dialog": "^1.0.3",
         "@radix-ui/react-avatar": "^1.0.2",
@@ -1352,12 +1343,12 @@
       }
     },
     "node_modules/@dxos/react-ui-theme": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/react-ui-theme/-/react-ui-theme-0.5.0.tgz",
-      "integrity": "sha512-2tr8PR/1iSkK4qWKzI+NQWv+H364YjYcJUTy5jsPQZYcttILqT3f8CHC0HP3bC91LTcIlmgrhWzTjTXMpd8+Rw==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/react-ui-theme/-/react-ui-theme-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-MvrbH8kAVNZChWUAhADIjzyWCsG+EX6FsuDGgTPpjaBNPJq30WxQfHuYseZgQJX43S9BPIlMlRJU3msXvj2ZYQ==",
       "dependencies": {
         "@ch-ui/colors": "^0.4.4",
-        "@dxos/node-std": "0.5.0",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
         "@fontsource-variable/inter": "^5.0.16",
         "@fontsource-variable/jetbrains-mono": "^5.0.16",
         "@tailwindcss/forms": "^0.5.3",
@@ -1374,53 +1365,52 @@
       }
     },
     "node_modules/@dxos/react-ui-types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/react-ui-types/-/react-ui-types-0.5.0.tgz",
-      "integrity": "sha512-ZCJpQ4HA+q833vvEh48C+BksZsFeQubnKzuuA4oOEPTzLfcqS60ijAkiL0DjMN3KXII/anfjtPXaPlqf1wxang=="
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/react-ui-types/-/react-ui-types-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-CLi+dSRlBOKdYaBmkKSQZr50eudBXh+Jnfv2F/k+Ud2O4l2zCZBw3HLAFNC5ChmDJoHDpuZ0Q34cDEYtOBb8xg=="
     },
     "node_modules/@dxos/rpc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/rpc/-/rpc-0.5.0.tgz",
-      "integrity": "sha512-ho+bKtGVCKQJiWC3Kqw2kzj99nYHGU/DHePab+NMdrAcNgBOHDqabVBazi4/SgkzHWwRTMKr5xlnZd/qvc5WBg==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/rpc/-/rpc-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-0dnSGzDpqswHyee+PtgbxHcakXE5EqlIr3XXk21sNo0V7MbfL0cJi+ppCHTjhpJ7AArLois5uZmhQ7u0sk9dOw==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/rpc-tunnel": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/rpc-tunnel/-/rpc-tunnel-0.5.0.tgz",
-      "integrity": "sha512-q3sUowZ8JhFQo+0UMHp6ItHfKnhUlu5ZXLOsmU61t5zD0SKEgCzm2+MVtX5Rq+VUeyqK5kEOHB/MUN7u/n2Vxg==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/rpc-tunnel/-/rpc-tunnel-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-3X2lIUoDTdpx3qP2/Zf4mQD7fxGFAkdn6uBgyq24mOpi9FpKF8vYZJwWjI4lU3KGTjEHwYl+rkryZGXsb2ETZA==",
       "dependencies": {
-        "@dxos/log": "0.5.0",
-        "@dxos/rpc": "0.5.0",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
         "ua-parser-js": "^1.0.35"
       }
     },
     "node_modules/@dxos/shell": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/shell/-/shell-0.5.0.tgz",
-      "integrity": "sha512-7Su1/LKc+8tKln8HP54N8odOAjZ95vmNnYAU8gbolqFxyZUo/tlGhvbE69eNu1a0MSPmnCpyZsA4qRS089A08w==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/shell/-/shell-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-0YrTNNEU6uTjZZQ5ihJ+MVJ2K4kNW8Q5onOvffdPoyiMGm+wCOGeegLxLgc5uUjkZhVQ+znzxYtUCSCGbKx0Ag==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/client-protocol": "0.5.0",
-        "@dxos/client-services": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/display-name": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/react-client": "0.5.0",
-        "@dxos/react-ui": "0.5.0",
-        "@dxos/react-ui-theme": "0.5.0",
-        "@dxos/react-ui-types": "0.5.0",
-        "@dxos/rpc-tunnel": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/client-protocol": "0.5.1-next.5a770e3",
+        "@dxos/client-services": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/display-name": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/react-ui": "0.5.1-next.5a770e3",
+        "@dxos/react-ui-theme": "0.5.1-next.5a770e3",
+        "@dxos/react-ui-types": "0.5.1-next.5a770e3",
+        "@dxos/rpc-tunnel": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@fluentui/react-tabster": "^9.19.0",
@@ -1437,164 +1427,165 @@
         "xstate": "^4.37.0"
       },
       "peerDependencies": {
+        "@dxos/react-client": "0.5.1-next.5a770e3",
         "@phosphor-icons/react": "^2.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
     },
     "node_modules/@dxos/teleport": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/teleport/-/teleport-0.5.0.tgz",
-      "integrity": "sha512-PftBiU0mIMRp/jT/RUL70PeVbxkdqMEtqJABUKbvYdjW3KjXsGJ8ZjiL2JWIx1dnKziPYLbnt7a5y4aqcYxdiA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/teleport/-/teleport-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-OB4JvIX7PeoSe3cxY+yUAVp4yehLvUymdwgmAkNzE92q09vpOpjAZBzsQ0WedsrLOwqYW61FnRfPuRHuUYMDvQ==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/util": "0.5.0",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
         "randombytes": "^2.1.0",
         "varint": "6.0.0"
       }
     },
     "node_modules/@dxos/teleport-extension-automerge-replicator": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/teleport-extension-automerge-replicator/-/teleport-extension-automerge-replicator-0.5.0.tgz",
-      "integrity": "sha512-uaXkL4e+qZIFiBr8ap9tl6ccc6+elRCQuXAJ11hunCCBfryStmlDYJeL7d6S2zvz6irp2UO4cp4QE1ckf9mTSA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/teleport-extension-automerge-replicator/-/teleport-extension-automerge-replicator-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-jio2wW1EuoVmnQNrIciDm5wqzmA/hf/ybp4qe6YRmJqteut547wfI8onR6NSHRc9Msndo/ntd4bjDsfizxODpw==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/teleport": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/teleport": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/teleport-extension-gossip": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/teleport-extension-gossip/-/teleport-extension-gossip-0.5.0.tgz",
-      "integrity": "sha512-tdcJPjpmjNJgnTIYrbwH0U2ZlSwlQeD5UbnhkkhLc8/pvq0Z9x47xzupjEX/QCg3O5scf2dss+uUz+A4U7r4pQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/teleport-extension-gossip/-/teleport-extension-gossip-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-gWWX6/lpSQliZ+U4PfmXm6QO9q8TvjQCbPad03exI5kzHQ60gR0Ct+NBqepiEI86VXNX6LknWk68laRFodtZVg==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/teleport": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/teleport": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/teleport-extension-object-sync": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/teleport-extension-object-sync/-/teleport-extension-object-sync-0.5.0.tgz",
-      "integrity": "sha512-TQIPXNgLOSSGSQ7H4TovjaNvvi5NdpsW3AKOrXoPF8CoIwU4r+raBG0qKbp2wpj28ogPKGznihuC9vkMnUGcmQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/teleport-extension-object-sync/-/teleport-extension-object-sync-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-kX2+ejAC2yhJlsPE4ihWkze8XsMRteo4VqgnKmgvLyQgPr3PVgWfQVV5hw59OxiLJm2ffUS/0/hlYwelxpiQIg==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/crypto": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/random-access-storage": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/teleport": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/crypto": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/random-access-storage": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/teleport": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/teleport-extension-replicator": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/teleport-extension-replicator/-/teleport-extension-replicator-0.5.0.tgz",
-      "integrity": "sha512-jxvsSwdO/oQ5+jh9hl9M5AIZ6zyfpLOXtVRMHyJB0xuNG6/nLWx+C5iK/+qQa9JrDMUpRREyFiB16BEDR4SVhA==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/teleport-extension-replicator/-/teleport-extension-replicator-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-Rmaiq6KNO3sdP0Nf0Ad9LNVa40qFb0ICDJCkWNtf9rShDKcNdJft2eVKenu4XmcJ8JkopipxBYd4Vk6msHRBdQ==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/feed-store": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/teleport": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/feed-store": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/teleport": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/timeframe": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/timeframe/-/timeframe-0.5.0.tgz",
-      "integrity": "sha512-IuEbZtB9yeS090yJcgsaBW377TheloOg3Jp8KDlFcB/j/3GJvDEMmL23vBbCBtbMwsl0ORPld+kGIlN+FKT6OQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/timeframe/-/timeframe-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-fcZnNDOLRKE+H+r0HCmsCvRr3p3NFaPdhIzkD5IGSzrvjGP3bzxHGpS9QZ3In+0pCKQh3PFmQYpTWtD3lMtXCQ==",
       "dependencies": {
-        "@dxos/debug": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/tracing": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/tracing/-/tracing-0.5.0.tgz",
-      "integrity": "sha512-IT+ShT83hBGFtHxa94XJtJr8iPbrnpcZEAZ+I+G0ZHcL9OyAU2poje9Z1WiemtrB/ui8w9LBhWfVN2jH1v8ESg==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/tracing/-/tracing-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-GVpexOvWvmU8ZoneBjd8GLU3d4EXI0rogzyl9okHIDuxVRX6oX8uqXCU4eDWq+IHQye5R68fwUIBDhLDyuNEyg==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/util": "0.5.0"
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/typings": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/typings/-/typings-0.5.0.tgz",
-      "integrity": "sha512-A08xj/AzxAIMr3GeRmJw5VX56gf7yOXVM2vIftJ/pgpI2OSoSDcaAS9KVLUueFtG7qJkDjJCJGCrMubVMdVosg=="
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/typings/-/typings-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-g7RkcqpDGrZev/X9SKKLZOhcN0bumhf/1ItI8M31kPmpftnJ0WZIQB4luY/93xM85HV/gumIjrMNCT/PS/ihdA=="
     },
     "node_modules/@dxos/util": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/util/-/util-0.5.0.tgz",
-      "integrity": "sha512-okUkGE2oAGCqwLd6Ahrw7oR2CdohTp/QHZ/mAUlU5gfGVXugdnTqNuv0ytYwRu84YQiHV2NMm1lZGB5vC6l8iQ==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/util/-/util-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-4Oiyg05LUCrHrLwy+lKYAlidYsfoCLbFjk/6fjDGvOF2AuO96x8N1B4NykAW/TXanLxlZESIVxjxdefeZnUPwQ==",
       "dependencies": {
-        "@dxos/debug": "0.5.0",
-        "@dxos/invariant": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/node-std": "0.5.0"
+        "@dxos/debug": "0.5.1-next.5a770e3",
+        "@dxos/invariant": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3"
       }
     },
     "node_modules/@dxos/websocket-rpc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@dxos/websocket-rpc/-/websocket-rpc-0.5.0.tgz",
-      "integrity": "sha512-7nlWTzsFbyasllqyfkG3aVCozl5cqTtVJokg5/Cyhsz+ups2JIkOeHcDKltS6ZVdy6Lh3Ot2JsY6yEd3Y0/cpg==",
+      "version": "0.5.1-next.5a770e3",
+      "resolved": "https://registry.npmjs.org/@dxos/websocket-rpc/-/websocket-rpc-0.5.1-next.5a770e3.tgz",
+      "integrity": "sha512-JGrJ9OhON/8vyZdFWLjD2wIuXyka839+TM9fMQFNe5Q2ZpCwSaLeojm/Nsq0kUzyLc76HfNYvvlUprF/9rAe6g==",
       "dependencies": {
-        "@dxos/async": "0.5.0",
-        "@dxos/codec-protobuf": "0.5.0",
-        "@dxos/context": "0.5.0",
-        "@dxos/keys": "0.5.0",
-        "@dxos/log": "0.5.0",
-        "@dxos/node-std": "0.5.0",
-        "@dxos/protocols": "0.5.0",
-        "@dxos/rpc": "0.5.0",
-        "@dxos/util": "0.5.0",
-        "isomorphic-ws": "^4.0.1",
+        "@dxos/async": "0.5.1-next.5a770e3",
+        "@dxos/codec-protobuf": "0.5.1-next.5a770e3",
+        "@dxos/context": "0.5.1-next.5a770e3",
+        "@dxos/keys": "0.5.1-next.5a770e3",
+        "@dxos/log": "0.5.1-next.5a770e3",
+        "@dxos/node-std": "0.5.1-next.5a770e3",
+        "@dxos/protocols": "0.5.1-next.5a770e3",
+        "@dxos/rpc": "0.5.1-next.5a770e3",
+        "@dxos/util": "0.5.1-next.5a770e3",
+        "isomorphic-ws": "^5.0.0",
         "ws": "^8.14.2"
       }
     },
@@ -1995,17 +1986,17 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.1.tgz",
-      "integrity": "sha512-42UH54oPZHPdRHdw6BgoBD6cg/eVTmVrFcgeRDM3jbO7uxSoipVcmcIGFcA5jmOHO5apcyvBhkSKES3fQJnu7A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.2.tgz",
+      "integrity": "sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==",
       "dependencies": {
         "@floating-ui/utils": "^0.2.0"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.4.tgz",
-      "integrity": "sha512-0G8R+zOvQsAG1pg2Q99P21jiqxqGBW1iRe/iXHsBRBxnpXKFI8QwbB4x5KmYLggNO5m34IQgOIu9SCRfR/WWiQ==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
+      "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
       "dependencies": {
         "@floating-ui/core": "^1.0.0",
         "@floating-ui/utils": "^0.2.0"
@@ -2037,9 +2028,9 @@
       }
     },
     "node_modules/@fluentui/react-shared-contexts": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.17.0.tgz",
-      "integrity": "sha512-SvfFmzzy0QfhaCrGcUJFJcscc6NGyuoYxT0Q8wgu5ol3vZ+idvVgGIJbhwQFVT08Ph5yR6FsWS22/nLjTqE58A==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.18.0.tgz",
+      "integrity": "sha512-++pttP1eEfpYUn0Sbtp4Yp2Uc3B+KRaQyfh3UZTt2G3HR0feL2V7yUEQsRVXv1JFw+Zz+L5ofJG+q87CCc8uUA==",
       "dependencies": {
         "@fluentui/react-theme": "^9.1.19",
         "@swc/helpers": "^0.5.1"
@@ -2050,17 +2041,17 @@
       }
     },
     "node_modules/@fluentui/react-tabster": {
-      "version": "9.21.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.21.0.tgz",
-      "integrity": "sha512-IlL2IBmGrC9tJSuxvNbit6/Euujc0rnwAvcb/u3ibduHdRYkWuzLyscUNTCWFjUiLNTWDw2ddY5tmRbW2M0TgQ==",
+      "version": "9.21.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.21.2.tgz",
+      "integrity": "sha512-K09KzSHr2RrRFhBbl20/5EZpXh2jaXxxgNPsp6dHAQ0kLSouVZ4hdvsykQEO+zgbztSEQEOiBlNTiCWLCmdpKQ==",
       "dependencies": {
-        "@fluentui/react-shared-contexts": "^9.17.0",
+        "@fluentui/react-shared-contexts": "^9.18.0",
         "@fluentui/react-theme": "^9.1.19",
-        "@fluentui/react-utilities": "^9.18.7",
+        "@fluentui/react-utilities": "^9.18.8",
         "@griffel/react": "^1.5.14",
         "@swc/helpers": "^0.5.1",
-        "keyborg": "^2.5.0",
-        "tabster": "^7.1.1"
+        "keyborg": "^2.6.0",
+        "tabster": "^7.1.2"
       },
       "peerDependencies": {
         "@types/react": ">=16.14.0 <19.0.0",
@@ -2079,12 +2070,12 @@
       }
     },
     "node_modules/@fluentui/react-utilities": {
-      "version": "9.18.7",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.18.7.tgz",
-      "integrity": "sha512-voVd4xrx+9VxCPYt51JlzLuJYsjCf3LYjoytAyruu7kEOkPF31Fnjkmp81yrXnAbM+J+tL8HajG5bUHjt8H59w==",
+      "version": "9.18.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.18.8.tgz",
+      "integrity": "sha512-cV/D0AMekH8lbtQB4XknOerMBIXARj/zOGm44SGyHgkL7Nk4YXyHKXDbWF0NHYQqFp/EmAPY6Dovq3dVO0iQvA==",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.7",
-        "@fluentui/react-shared-contexts": "^9.17.0",
+        "@fluentui/react-shared-contexts": "^9.18.0",
         "@swc/helpers": "^0.5.1"
       },
       "peerDependencies": {
@@ -2111,12 +2102,12 @@
       "integrity": "sha512-LL/57KBbM3r0UMuN6tSeYExiBObt0QuGq49m1FyoDFIv1GAcuKU0EQ/GAKJ/yt3R8onOCD3f5X9Dln//G6uzRQ=="
     },
     "node_modules/@griffel/core": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.15.3.tgz",
-      "integrity": "sha512-5ksBpOjFJ75HijGehQ06Ri9cQjhd/rqQ0N/jJzXDDXQFYdOOzib/QL7BXNwhkLtTyHvN391cD4/BqcTdynfLUg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.16.0.tgz",
+      "integrity": "sha512-7xy9sWxmyFok0chZXJ91z4VH0HdwhAPUln5Ctpg6S/WRKoPhpIg9EieiL5CRFhIp1krPIncJSes4WqaB9OKiow==",
       "dependencies": {
         "@emotion/hash": "^0.9.0",
-        "@griffel/style-types": "^1.0.4",
+        "@griffel/style-types": "^1.1.0",
         "csstype": "^3.1.3",
         "rtl-css-js": "^1.16.1",
         "stylis": "^4.2.0",
@@ -2124,11 +2115,11 @@
       }
     },
     "node_modules/@griffel/react": {
-      "version": "1.5.21",
-      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.5.21.tgz",
-      "integrity": "sha512-7wuY9uFSt/0E7kLAKX//ue8NILx0IGoOtIx6WVuavEUFJXPCrvFn4uCDgnJC0211LZtJ+XH7zZGPNUtSb7nijw==",
+      "version": "1.5.22",
+      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.5.22.tgz",
+      "integrity": "sha512-QZWo73e+7oh+aTxCJzCe9SNUszM0+lHG9p1LoEQ5MZdvtT8sur1M4cz+TVTTgUXqUBnHBf1TIYXvVoRxiZhy8Q==",
       "dependencies": {
-        "@griffel/core": "^1.15.3",
+        "@griffel/core": "^1.16.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2136,9 +2127,9 @@
       }
     },
     "node_modules/@griffel/style-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.0.4.tgz",
-      "integrity": "sha512-geZomjQTIHXoQZFFB811PUMXYAr8LuBNOMPcR2YJAl1pslbHYYiZKCa2FgZCw00hnQFP4uB4JIJ2CiPJqKZYmw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.1.0.tgz",
+      "integrity": "sha512-cINLeC14/YUHlrtL96vzCrsFr19WUO0i9DuljBtX5S7B8pMyiNf6Pw0htjroLojvfD2okhdsr9CHwpUxz1u4kw==",
       "dependencies": {
         "csstype": "^3.1.3"
       }
@@ -2375,9 +2366,9 @@
       }
     },
     "node_modules/@orama/orama": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-2.0.17.tgz",
-      "integrity": "sha512-RU0oGnV/ieaiLnMhCsVZcJTOT0bo5ne0KndEK7xMHsvA2RDAt8za2XFW57JaMWgBXLDKNX+Q5CHKje72PS6uzw==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-2.0.18.tgz",
+      "integrity": "sha512-KSty7+r8JxXv3iCuhLqQfwMvUiSWnXPaTPQPPoVPpwdvynEKcp1JNWKzTMB2tISDggf8jKhQXHEP3QXlGkvvtA==",
       "engines": {
         "node": ">= 16.0.0"
       }
@@ -4522,22 +4513,30 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4780,6 +4779,8 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "optional": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4791,6 +4792,8 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5528,7 +5531,9 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5766,6 +5771,8 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -5965,21 +5972,21 @@
       }
     },
     "node_modules/esbuild-style-plugin/node_modules/glob": {
-      "version": "10.3.12",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
-      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
+      "version": "10.3.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.15.tgz",
+      "integrity": "sha512-0c6RlJt1TICLyvJYIApxb8GsXoai0KUP7AxKKAtsYXdgJR1mGEUa7DgwShbdk1nly0PYoZj01xd4hzbq3fsjpw==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.6",
         "minimatch": "^9.0.1",
         "minipass": "^7.0.4",
-        "path-scurry": "^1.10.2"
+        "path-scurry": "^1.11.0"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6000,9 +6007,9 @@
       }
     },
     "node_modules/esbuild-style-plugin/node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
+      "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -6809,9 +6816,9 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "peerDependencies": {
         "ws": "*"
       }
@@ -6916,10 +6923,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyborg": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.5.0.tgz",
-      "integrity": "sha512-nb4Ji1suqWqj6VXb61Jrs4ab/UWgtGph4wDch2NIZDfLBUObmLcZE0aiDjZY49ghtu03fvwxDNvS9ZB0XMz6/g=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.6.0.tgz",
+      "integrity": "sha512-o5kvLbuTF+o326CMVYpjlaykxqYP9DphFQZ2ZpgrvBouyvOxyEB7oqe8nOLFpiV5VCtz0D3pt8gXQYWpLpBnmA=="
     },
     "node_modules/lcid": {
       "version": "1.0.0",
@@ -7352,7 +7367,9 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/memdown": {
       "version": "5.1.0",
@@ -7733,9 +7750,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -8002,15 +8019,15 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
-      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -8330,9 +8347,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
-      "version": "10.21.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.21.0.tgz",
-      "integrity": "sha512-aQAIxtzWEwH8ou+OovWVSVNlFImL7xUCwJX3YMqA3U8iKCNC34999fFOnWjYNsylgfPgMexpbk7WYOLtKr/mxg==",
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.0.tgz",
+      "integrity": "sha512-RRurnSjJPj4rp5K6XoP45Ui33ncb7e4H7WiOHVpjbkvqvA3U+N8Z6Qbo0AE6leGYBV66n8EhEaFixvIu3SkxFw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -8364,9 +8381,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -9064,34 +9081,15 @@
       "optional": true
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -9547,11 +9545,11 @@
       }
     },
     "node_modules/tabster": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/tabster/-/tabster-7.1.1.tgz",
-      "integrity": "sha512-3VsXUb0XxVcFq9NmzTieAJAlruMiaj/dvXIHm7RgjsUrMGkEcq9KbBdai05NAGp2D2d/CxHc6j1mbuUzGofWBA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/tabster/-/tabster-7.1.2.tgz",
+      "integrity": "sha512-wYG9ddAeSUxBrcPCZ+hQV5IcsyM089nTGkQ53G9/2pPDdUa3pBC4sP3qmdbvu+IoFpy62CMDxMgxQmegtCiLKg==",
       "dependencies": {
-        "keyborg": "2.5.0",
+        "keyborg": "2.6.0",
         "tslib": "^2.3.1"
       }
     },
@@ -9825,11 +9823,6 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
-    "node_modules/tiny-typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
-    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -9864,6 +9857,8 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9905,7 +9900,9 @@
     "node_modules/ts-node/node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tslib": {
       "version": "2.6.2",
@@ -9927,6 +9924,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10096,6 +10094,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -10107,7 +10106,9 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -10510,6 +10511,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "serve": "vite"
   },
   "dependencies": {
-    "@dxos/client": "0.5.0",
-    "@dxos/config": "0.5.0",
-    "@dxos/echo-schema": "0.5.0",
-    "@dxos/react-client": "0.5.0",
-    "@dxos/shell": "0.5.0",
+    "@dxos/client": "0.5.1-next.5a770e3",
+    "@dxos/config": "0.5.1-next.5a770e3",
+    "@dxos/echo-schema": "0.5.1-next.5a770e3",
+    "@dxos/react-client": "0.5.1-next.5a770e3",
+    "@dxos/shell": "0.5.1-next.5a770e3",
     "@phosphor-icons/react": "^2.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/Contact.tsx
+++ b/src/Contact.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
-import { ContactType } from "./types";
 import { ReactiveObject } from "@dxos/echo-schema";
 
 export type ContactProps = {
@@ -20,9 +19,6 @@ const contactIsEmpty = (contact: ReactiveObject<any>) => {
   );
 };
 
-type ContactTypeKey = keyof ReactiveObject<any>;
-// --/
-
 export const Contact = ({ contact, onCreate, onDelete }: ContactProps) => {
   const [editMode, setEditMode] = useState(false);
   const [formState, setFormState] = useState<ReactiveObject<any>>(
@@ -30,11 +26,8 @@ export const Contact = ({ contact, onCreate, onDelete }: ContactProps) => {
     JSON.parse(JSON.stringify(contact))
   );
 
-  console.log("rendering contact");
-
   useEffect(() => {
     setFormState(JSON.parse(JSON.stringify(contact)));
-    console.log("contact changed");
   }, [JSON.stringify(contact)]);
 
   // TODO(jm): more appropriate React way to do this?

--- a/src/Contact.tsx
+++ b/src/Contact.tsx
@@ -1,15 +1,16 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { ContactType } from "./types";
+import { ReactiveObject } from "@dxos/echo-schema";
 
 export type ContactProps = {
-  contact: ContactType | null;
+  contact: ReactiveObject<any> | null;
   onCreate: () => void;
-  onDelete: (contact: ContactType) => void;
+  onDelete: (contact: ReactiveObject<any>) => void;
 };
 
 // -- TODO(Zan): Move to contact module
-const contactIsEmpty = (contact: ContactType) => {
+const contactIsEmpty = (contact: ReactiveObject<any>) => {
   return (
     !contact.firstName &&
     !contact.lastName &&
@@ -19,15 +20,22 @@ const contactIsEmpty = (contact: ContactType) => {
   );
 };
 
-type ContactTypeKey = keyof ContactType;
+type ContactTypeKey = keyof ReactiveObject<any>;
 // --/
 
 export const Contact = ({ contact, onCreate, onDelete }: ContactProps) => {
   const [editMode, setEditMode] = useState(false);
-  const [formState, setFormState] = useState<ContactType>(
+  const [formState, setFormState] = useState<ReactiveObject<any>>(
     // Hack to make a deep copy of the contact object and eject from the reactive proxy.
     JSON.parse(JSON.stringify(contact))
   );
+
+  console.log("rendering contact");
+
+  useEffect(() => {
+    setFormState(JSON.parse(JSON.stringify(contact)));
+    console.log("contact changed");
+  }, [JSON.stringify(contact)]);
 
   // TODO(jm): more appropriate React way to do this?
   const firstNameInputRef = useRef<HTMLInputElement>(null);
@@ -40,10 +48,7 @@ export const Contact = ({ contact, onCreate, onDelete }: ContactProps) => {
   }, [contact, setEditMode]);
 
   const updateContactField = useCallback(
-    <Field extends ContactTypeKey>(
-      field: Field,
-      newValue: ContactType[Field]
-    ) => {
+    (field: string, newValue: any) => {
       // Mutate the reactive echo object
       contact[field] = newValue;
     },
@@ -65,33 +70,45 @@ export const Contact = ({ contact, onCreate, onDelete }: ContactProps) => {
           <input
             ref={firstNameInputRef}
             type="text"
-            value={formState.firstName}
+            value={formState?.firstName}
             onChange={(e) =>
               setFormState((state) => ({ ...state, firstName: e.target.value }))
             }
             onBlur={(e) => updateContactField("firstName", e.target.value)}
             className="rounded border px-2 py-1 text-2xl font-bold text-center"
-            style={{ width: `${formState.firstName.length + 1}ch` }}
+            style={{
+              width: `${
+                formState?.firstName ? formState?.firstName.length + 1 : 0
+              }ch`,
+            }}
           />
           <input
             type="text"
-            value={formState.lastName}
+            value={formState?.lastName}
             onChange={(e) =>
               setFormState((state) => ({ ...state, lastName: e.target.value }))
             }
             onBlur={(e) => updateContactField("lastName", e.target.value)}
             className="rounded border px-2 py-1 text-2xl font-bold text-center"
-            style={{ width: `${formState.lastName.length + 1}ch` }}
+            style={{
+              width: `${
+                formState?.lastName ? formState.lastName.length + 1 : 0
+              }ch`,
+            }}
           />
         </div>
       ) : (
         <div className="mb-4 border border-white px-2 py-1 text-center text-2xl font-bold dark:border-black dark:text-gray-200">
-          {formState.firstName.length > 0 ? formState.firstName : "\u00A0"}{" "}
-          {formState.lastName.length > 0 ? formState.lastName : "\u00A0"}
+          {formState?.firstName && formState.firstName.length > 0
+            ? formState.firstName
+            : "\u00A0"}{" "}
+          {formState?.lastName && formState.lastName.length > 0
+            ? formState.lastName
+            : "\u00A0"}
         </div>
       )}
       <div className="flex flex-col">
-        {(["email", "phone", "website"] as ContactTypeKey[]).map((field) => {
+        {["email", "phone", "website"].map((field) => {
           return (
             <div
               key={field}
@@ -115,7 +132,7 @@ export const Contact = ({ contact, onCreate, onDelete }: ContactProps) => {
                   />
                 </div>
               ) : (
-                <div className="px-2 py-1">{contact[field] ?? ""}</div>
+                <div className="px-2 py-1">{formState[field] ?? ""}</div>
               )}
             </div>
           );

--- a/src/ContactsPage.tsx
+++ b/src/ContactsPage.tsx
@@ -1,7 +1,7 @@
 import { useShell } from "@dxos/react-client";
 import { Filter, create, useQuery, useSpace } from "@dxos/react-client/echo";
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { Contact } from "./Contact";
@@ -19,8 +19,14 @@ export const ContactsPage = () => {
   if (!space) {
     console.log("WARNING: space not found!");
   } else {
-    space.db.schemaRegistry.add(ContactType);
+    // space.db.schemaRegistry.add(ContactType);
   }
+
+  useEffect(() => {
+    if (space) {
+      space.db.schemaRegistry.add(ContactType);
+    }
+  }, [space]);
 
   // Fetch the contacts objects
   const contacts = useQuery(space, Filter.schema(ContactType));

--- a/src/ContactsPage.tsx
+++ b/src/ContactsPage.tsx
@@ -13,10 +13,13 @@ export const ContactsPage = () => {
   const { spaceKey } = useParams<{ spaceKey: string }>();
 
   const space = useSpace(spaceKey);
+
   const shell = useShell();
 
   if (!space) {
     console.log("WARNING: space not found!");
+  } else {
+    space.db.schemaRegistry.add(ContactType);
   }
 
   // Fetch the contacts objects

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,9 @@ export class ContactType extends TypedObject({
   typename: "dxos.app.contacts.Contact",
   version: "0.1.0",
 })({
-  firstName: S.string,
-  lastName: S.string,
-  website: S.string,
-  phone: S.string,
-  email: S.string,
+  firstName: S.optional(S.string),
+  lastName: S.optional(S.string),
+  website: S.optional(S.string),
+  phone: S.optional(S.string),
+  email: S.optional(S.string),
 }) {}


### PR DESCRIPTION
In order to persist the schema to the database and have the same objects be query-able in both places, I have to use the schema returned from the db. This means I lose type information and have to change how I create and query for the objects.

This shouldn't be needed because ECHO should handle this intelligently for me, but it's fine for now.